### PR TITLE
Track merge request conflicts

### DIFF
--- a/api/GitLab.js
+++ b/api/GitLab.js
@@ -26,6 +26,7 @@ class GitLab {
       state: "opened",
       scope: "all",
       wip: "no",
+      with_merge_status_recheck: true,
     }
 
     const uri = this.__getUrl("projects", project, "merge_requests")

--- a/gbot.example.yml
+++ b/gbot.example.yml
@@ -34,6 +34,7 @@ unapproved:
     author: false
     commenters: false
     onThreadsOpen: false
+    onConflict: false
   diffs: false
   splitByReviewProgress: false
   requestsPerMessage: 15

--- a/tasks/Unapproved.js
+++ b/tasks/Unapproved.js
@@ -118,8 +118,7 @@ class Unapproved extends BaseCommand {
   )
 
   __chunkRequests = requests => {
-    const requestsPerMessage = this.__getConfigSetting("unapproved.requestsPerMessage")
-    if (!requestsPerMessage) return [requests]
+    const requestsPerMessage = this.__getConfigSetting("unapproved.requestsPerMessage", 10000)
 
     return _.chunk(requests, requestsPerMessage)
   }
@@ -136,8 +135,9 @@ class Unapproved extends BaseCommand {
       const isUnapproved = req.approvals_left > 0
       const isUnderReview = this.__isRequestUnderReview(req)
       const hasPathsChanges = this.__hasPathsChanges(req.changes, project.paths)
+      const hasConflicts = req.has_conflicts
 
-      return isCompleted && hasPathsChanges && (isUnapproved || isUnderReview)
+      return isCompleted && hasPathsChanges && (isUnapproved || isUnderReview || hasConflicts)
     }))
 
   __isRequestUnderReview = req => req.discussions


### PR DESCRIPTION
1. Include merge requests with conflicts in message
2. Fix emoji (take field `updated_at` instead of undefined `updated`)
3. Fix empty section (chunk by 10000 requests if not set in config)