### PR TITLE
Remove merge status recheck

### DIFF
--- a/api/GitLab.js
+++ b/api/GitLab.js
@@ -20,14 +20,13 @@ class GitLab {
 
   project = id => this.__get(this.__getUrl("projects", id))
 
-  requests = (project, { withMergeStatusRecheck }) => {
+  requests = project => {
     const query = {
       sort: "asc",
       per_page: 100,
       state: "opened",
       scope: "all",
       wip: "no",
-      with_merge_status_recheck: withMergeStatusRecheck,
     }
 
     const uri = this.__getUrl("projects", project, "merge_requests")

--- a/api/Messenger.js
+++ b/api/Messenger.js
@@ -23,9 +23,9 @@ class Messenger {
   }
 
   sendMany = messages => {
-    _.castArray(messages).forEach((message, idx) => {
-      _.delay(() => this.send(message), 100 * idx)
-    })
+    return messages.reduce((promise, message) => {
+      return promise.then(() => this.send(message))
+    }, Promise.resolve())
   }
 }
 

--- a/api/Messenger.js
+++ b/api/Messenger.js
@@ -23,7 +23,7 @@ class Messenger {
   }
 
   sendMany = messages => {
-    return messages.reduce((promise, message) => {
+    return _.castArray(messages).reduce((promise, message) => {
       return promise.then(() => this.send(message))
     }, Promise.resolve())
   }

--- a/tasks/Unapproved.js
+++ b/tasks/Unapproved.js
@@ -175,12 +175,10 @@ class Unapproved extends BaseCommand {
   }
 
   __getExtendedRequests = projectId => {
-    const checkConflicts = this.__getConfigSetting("unapproved.checkConflicts", false)
-
     return this.gitlab
       .project(projectId)
       .then(project => this.gitlab
-        .requests(project.id, { withMergeStatusRecheck: checkConflicts })
+        .requests(project.id)
         .then(requests => {
           const promises = requests.map(request => this.__getExtendedRequest(project, request))
           return Promise.all(promises)


### PR DESCRIPTION
- I have removed `with_merge_status_recheck` parameter because it adds instability
- I have chained promises to send message to slack instead of delay