### PR TITLE
Add slack text markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbrellio/gbot",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "bin": "gbot",
   "repository": "git@github.com:umbrellio/gbot.git",
   "author": "Aleksei Bespalov <nulldefiner@gmail.com>",

--- a/utils/markup.js
+++ b/utils/markup.js
@@ -16,6 +16,24 @@ const markdown = {
   composeMsg: body => ({ text: body }),
 }
 
+const slackText = {
+  type: "slackText",
+  makeLink: (title, url) => `<${url}|${title}>`,
+  makeText: text => text,
+  makePrimaryInfo: info => info,
+  makeAdditionalInfo: parts => parts.join("\n"),
+  makeBold: content => `*${content}*`,
+  makeHeader: text => `*${text}*`,
+  mention: (username, mapping) => (
+    mapping[username] ? `<@${mapping[username]}>` : `@${username}`
+  ),
+  addDivider: parts => `${parts} \n`,
+  flatten: parts => parts.join("\n"),
+  withHeader: (header, body) => `${header}\n\n${body}`,
+  composeBody: (main, secondary) => _.compact([main, secondary]).join("\n"),
+  composeMsg: body => ({ text: body }),
+}
+
 const slack = {
   type: "slack",
   makeLink: (title, url) => `<${url}|${title}>`,
@@ -53,4 +71,4 @@ const slack = {
   composeMsg: body => ({ blocks: _.castArray(body) }),
 }
 
-module.exports = { slack, markdown }
+module.exports = { slack, slackText, markdown }


### PR DESCRIPTION
I have added slack text markup because for slack markup (blocks in request) it doesn't support full width.